### PR TITLE
Update to use `prop-types` package

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 
 import {
@@ -19,7 +19,7 @@ const styles = {
   }
 }
 
-class Example extends React.Component {
+class Example extends Component {
   state = {
     feature1: true,
     feature2: false

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "mocha": "^3.0.2",
+    "prop-types": "^15.5.10",
     "random-string": "^0.1.2",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.3.0",

--- a/src/feature_gate.js
+++ b/src/feature_gate.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import PropTypes from 'prop-types'
 
 export function FeatureGate(props, context) {
   const {children, feature} = props

--- a/src/feature_gate.js
+++ b/src/feature_gate.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { PropTypes } from 'react'
 
 export function FeatureGate(props, context) {
   const {children, feature} = props
@@ -8,12 +8,12 @@ export function FeatureGate(props, context) {
 }
 
 FeatureGate.contextTypes = {
-  features: React.PropTypes.object.isRequired
+  features: PropTypes.object.isRequired
 }
 
 FeatureGate.propTypes = {
-  children: React.PropTypes.any,
-  feature: React.PropTypes.string.isRequired
+  children: PropTypes.any,
+  feature: PropTypes.string.isRequired
 }
 
 export default FeatureGate

--- a/src/feature_provider.js
+++ b/src/feature_provider.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 export class FeatureProvider extends Component {
   static childContextTypes = {

--- a/src/feature_provider.js
+++ b/src/feature_provider.js
@@ -1,13 +1,13 @@
-import React from 'react'
+import React, { Component, PropTypes } from 'react'
 
-export class FeatureProvider extends React.Component {
+export class FeatureProvider extends Component {
   static childContextTypes = {
-    features: React.PropTypes.object.isRequired
+    features: PropTypes.object.isRequired
   }
 
   static propTypes = {
-    children: React.PropTypes.any,
-    features: React.PropTypes.object.isRequired
+    children: PropTypes.any,
+    features: PropTypes.object.isRequired
   }
 
   getChildContext() {


### PR DESCRIPTION
- Change imports to use destructuring for React classes
- Use [`prop-types`](https://www.npmjs.com/package/prop-types) package instead of [deprecated `React.PropTypes` ](https://facebook.github.io/react/warnings/dont-call-proptypes.html)